### PR TITLE
Fixed bug in MarkdownCode

### DIFF
--- a/MarkdownKit/Classes/Elements/MarkdownCode.swift
+++ b/MarkdownKit/Classes/Elements/MarkdownCode.swift
@@ -9,26 +9,26 @@
 import UIKit
 
 public class MarkdownCode: MarkdownCommonElement {
-  
-  private static let regex = "(`+)(\\s*.*?[^`]\\s*)(\\1)(?!`)"
-  
-  public var font: UIFont?
-  public var color: UIColor?
-  
-  public var regex: String {
-    return MarkdownCode.regex
-  }
-  
-  public init(font: UIFont? = UIFont(name: "Courier New",size: UIFont.smallSystemFontSize()),
-       color: UIColor? = nil) {
-    self.font = font
-    self.color = color
-  }
-  
-  public func match(match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
-    let matchString = attributedString.attributedSubstringFromRange(match.range).string
-    guard let unescapedString = matchString.unescapeUTF16() else { return }
-    attributedString.replaceCharactersInRange(match.range, withString: unescapedString)
-    addAttributes(attributedString, range: match.range)
-  }
+    
+    private static let regex = "(`+)(\\s*.*?[^`]\\s*)(\\1)(?!`)"
+    
+    public var font: UIFont?
+    public var color: UIColor?
+    
+    public var regex: String {
+        return MarkdownCode.regex
+    }
+    
+    public init(font: UIFont? = UIFont(name: "Courier New",size: UIFont.smallSystemFontSize()),
+                color: UIColor? = nil) {
+        self.font = font
+        self.color = color
+    }
+    
+    public func addAttributes(attributedString: NSMutableAttributedString, range: NSRange) {
+        let matchString = attributedString.attributedSubstringFromRange(range).string
+        guard let unescapedString = matchString.unescapeUTF16() else { return }
+        attributedString.replaceCharactersInRange(range, withString: unescapedString)
+        attributedString.addAttributes(attributes, range: NSRange(location: range.location, length: unescapedString.characters.count))
+    }
 }


### PR DESCRIPTION
Fixed crash bug and false text displaying while parsing markdown raw text with `MarkdownCode`.

Reason for crash: the length of an unescapedString, which is the receiver of func `unescapeUTF16()`, may not  be devided by 4, thus the implementation in `unescapeUTF16()` may exceeds the index of  `String.characters`.

Reason for false text displaying: wrong order of each 4 characters in an unescaped string.
For example: hex string: ... abcd efgh wert ... ->(wrong order)-> ... cdef ghwe ...